### PR TITLE
Created simplytest roles and permissions.

### DIFF
--- a/config/install/user.role.simplytest_manager.yml
+++ b/config/install/user.role.simplytest_manager.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+id: simplytest_manager
+label: Manager
+weight: 3
+is_admin: false
+permissions:
+  - administer submission entities
+  - create submission entities

--- a/modules/simplytest_submission/simplytest_submission.permissions.yml
+++ b/modules/simplytest_submission/simplytest_submission.permissions.yml
@@ -1,0 +1,5 @@
+administer submission entities:
+  title: 'Administer submissions and submissions settings'
+  restrict access: true
+create submission entities:
+  title: 'Create submissions'

--- a/modules/simplytest_submission/src/SubmissionAccessControlHandler.php
+++ b/modules/simplytest_submission/src/SubmissionAccessControlHandler.php
@@ -22,16 +22,13 @@ class SubmissionAccessControlHandler extends EntityAccessControlHandler {
     if ($result->isNeutral()) {
       switch ($operation) {
         case 'view':
-          return AccessResult::allowedIfHasPermission($account, 'view submission entities');
+          return AccessResult::allowedIfHasPermission($account, 'administer submission entities');
 
         case 'update':
-          return AccessResult::allowedIfHasPermission($account, 'edit submission entities');
-
-        case 'manage':
-          return AccessResult::allowedIfHasPermission($account, 'manage submission entities');
+          return AccessResult::allowedIfHasPermission($account, 'administer submission entities');
 
         case 'delete':
-          return AccessResult::allowedIfHasPermission($account, 'delete submission entities');
+          return AccessResult::allowedIfHasPermission($account, 'administer submission entities');
       }
     }
     return $result;
@@ -43,7 +40,7 @@ class SubmissionAccessControlHandler extends EntityAccessControlHandler {
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
     $result = parent::checkCreateAccess($account, $context, $entity_bundle);
     if ($result->isNeutral()) {
-      return AccessResult::allowed();
+      return AccessResult::allowedIfHasPermission($account, 'create submission entities');
     }
     return $result;
   }

--- a/modules/simplytest_submission/src/SubmissionHtmlRouteProvider.php
+++ b/modules/simplytest_submission/src/SubmissionHtmlRouteProvider.php
@@ -54,7 +54,7 @@ class SubmissionHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_entity_list' => $entity_type_id,
           '_title' => "{$entity_type->getLabel()} list",
         ])
-        ->setRequirement('_permission', 'view submission entities')
+        ->setRequirement('_permission', 'administer submission entities')
         ->setOption('_admin_route', TRUE);
 
       return $route;
@@ -135,7 +135,7 @@ class SubmissionHtmlRouteProvider extends AdminHtmlRouteProvider {
         '_controller' => '\Drupal\simplytest_submission\Controller\SimplytestSubmissionController::submissionProgress',
         '_title' => "Thank your for your submission",
       ])
-      ->setRequirement('_permission', 'create submission content');
+      ->setRequirement('_permission', 'create submission entities');
 
     $route->setOption('parameters', $parameters);
     return $route;
@@ -189,7 +189,7 @@ class SubmissionHtmlRouteProvider extends AdminHtmlRouteProvider {
         '_controller' => '\Drupal\simplytest_submission\Controller\SimplytestSubmissionController::deleteSubmissionInstance',
         '_title' => "Delete Instance",
       ])
-      ->setRequirement('_permission', 'delete submission content');
+      ->setRequirement('_permission', 'administer submission entities');
 
     $route->setOption('parameters', $parameters)
       ->setOption('_admin_route', TRUE);

--- a/simplytest.install
+++ b/simplytest.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\user\Entity\User;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_install().
@@ -21,6 +22,10 @@ function simplytest_install() {
   // Allow visitor account creation with administrative approval.
   $user_settings = \Drupal::configFactory()->getEditable('user.settings');
   $user_settings->set('register', USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL)->save(TRUE);
+
+  // Enable default permissions for system roles.
+  user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['create submission entities']);
+  user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['create submission entities']);
 
   // Assign user 1 the "administrator" role.
   $user = User::load(1);

--- a/simplytest.links.menu.yml
+++ b/simplytest.links.menu.yml
@@ -2,3 +2,8 @@ simplytest.front_page:
   title: 'Home'
   route_name: '<front>'
   menu_name: main
+
+simplytest.submission_list:
+  title: 'Submissions'
+  route_name: 'entity.simplytest_submission.collection'
+  menu_name: main


### PR DESCRIPTION
This is a PR for issue: https://github.com/yanniboi/simplytest/issues/14

I have:

- Created a 'create submission entities' permission for the add form and the progress page.
- Created an 'administer submission entities' permission for all other pages and operations.
- Created a new role for the simplytest profile that is 'Submission Manager' who has both create and administer permissions.
- Granted permission for both anonymous and authenticated user roles to create submissions during profile installation.
- Added a link to the main menu for the 'Submissions list' as the manager role does not have access to the admin theme/menu and would not be able to find this page otherwise.